### PR TITLE
Update metrics in README to reflect new names

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,13 +22,13 @@ resp, err := githubClient.Get("https://api.github.com/repos/travelaudience/go-pr
 
 Doing so will give you prometheus metrics such as:
 
-| metric                             | description                               |
-|------------------------------------|-------------------------------------------|
-| requests_total                     | A counter for outgoing requests.          |
-| request_duration_histogram_seconds | A histogram of outgoing request latencies. |
-| dns_duration_histogram_seconds     | Trace dns latency histogram.              |
-| tls_duration_histogram_seconds     | Trace tls latency histogram.              |
-| in_flight_requests                 | A gauge of in-flight outgoing requests.    |
+| metric                                             | description                                |
+|----------------------------------------------------|--------------------------------------------|
+| `http_outgoing_requests_total`                     | A counter for outgoing requests.           |
+| `http_outgoing_request_duration_histogram_seconds` | A histogram of outgoing request latencies. |
+| `http_outgoing_dns_duration_histogram_seconds`     | Trace dns latency histogram.               |
+| `http_outgoing_tls_duration_histogram_seconds`     | Trace tls latency histogram.               |
+| `http_outgoing_in_flight_requests`                 | A gauge of in-flight outgoing requests.    |
 
 By calling httpClient.ForRecipient("github"), all of these metrics will be tagged with the label `"recipient": "github"`
 


### PR DESCRIPTION
Looks like these are prefixed now - I just ran this library and got this:

```
# HELP http_outgoing_dns_duration_histogram_seconds Trace dns latency histogram.
# TYPE http_outgoing_dns_duration_histogram_seconds histogram
http_outgoing_dns_duration_histogram_seconds_bucket{event="dns_done",recipient="domain",le="0.005"} 0
http_outgoing_dns_duration_histogram_seconds_bucket{event="dns_done",recipient="domain",le="0.01"} 0
http_outgoing_dns_duration_histogram_seconds_bucket{event="dns_done",recipient="domain",le="0.025"} 0
http_outgoing_dns_duration_histogram_seconds_bucket{event="dns_done",recipient="domain",le="0.05"} 0
http_outgoing_dns_duration_histogram_seconds_bucket{event="dns_done",recipient="domain",le="+Inf"} 0
http_outgoing_dns_duration_histogram_seconds_sum{event="dns_done",recipient="domain"} 0
http_outgoing_dns_duration_histogram_seconds_count{event="dns_done",recipient="domain"} 0
http_outgoing_dns_duration_histogram_seconds_bucket{event="dns_start",recipient="domain",le="0.005"} 0
http_outgoing_dns_duration_histogram_seconds_bucket{event="dns_start",recipient="domain",le="0.01"} 0
http_outgoing_dns_duration_histogram_seconds_bucket{event="dns_start",recipient="domain",le="0.025"} 0
http_outgoing_dns_duration_histogram_seconds_bucket{event="dns_start",recipient="domain",le="0.05"} 0
http_outgoing_dns_duration_histogram_seconds_bucket{event="dns_start",recipient="domain",le="+Inf"} 0
http_outgoing_dns_duration_histogram_seconds_sum{event="dns_start",recipient="domain"} 0
http_outgoing_dns_duration_histogram_seconds_count{event="dns_start",recipient="domain"} 0
# HELP http_outgoing_in_flight_requests A gauge of in-flight outgoing requests for the wrapped client.
# TYPE http_outgoing_in_flight_requests gauge
http_outgoing_in_flight_requests{recipient="domain"} 0
# HELP http_outgoing_request_duration_histogram_seconds A histogram of outgoing request latencies.
# TYPE http_outgoing_request_duration_histogram_seconds histogram
http_outgoing_request_duration_histogram_seconds_bucket{method="post",recipient="domain",le="0.005"} 0
http_outgoing_request_duration_histogram_seconds_bucket{method="post",recipient="domain",le="0.01"} 0
http_outgoing_request_duration_histogram_seconds_bucket{method="post",recipient="domain",le="0.025"} 0
http_outgoing_request_duration_histogram_seconds_bucket{method="post",recipient="domain",le="0.05"} 0
http_outgoing_request_duration_histogram_seconds_bucket{method="post",recipient="domain",le="0.1"} 5
http_outgoing_request_duration_histogram_seconds_bucket{method="post",recipient="domain",le="0.25"} 9
http_outgoing_request_duration_histogram_seconds_bucket{method="post",recipient="domain",le="0.5"} 18
http_outgoing_request_duration_histogram_seconds_bucket{method="post",recipient="domain",le="1"} 21
http_outgoing_request_duration_histogram_seconds_bucket{method="post",recipient="domain",le="2.5"} 21
http_outgoing_request_duration_histogram_seconds_bucket{method="post",recipient="domain",le="5"} 21
http_outgoing_request_duration_histogram_seconds_bucket{method="post",recipient="domain",le="10"} 21
http_outgoing_request_duration_histogram_seconds_bucket{method="post",recipient="domain",le="+Inf"} 21
http_outgoing_request_duration_histogram_seconds_sum{method="post",recipient="domain"} 6.224092123
http_outgoing_request_duration_histogram_seconds_count{method="post",recipient="domain"} 21
# HELP http_outgoing_requests_total A counter for outgoing requests from the wrapped client.
# TYPE http_outgoing_requests_total counter
http_outgoing_requests_total{code="200",method="post",recipient="domain"} 21
# HELP http_outgoing_tls_duration_histogram_seconds Trace tls latency histogram.
# TYPE http_outgoing_tls_duration_histogram_seconds histogram
http_outgoing_tls_duration_histogram_seconds_bucket{event="tls_handshake_done",recipient="domain",le="0.05"} 0
http_outgoing_tls_duration_histogram_seconds_bucket{event="tls_handshake_done",recipient="domain",le="0.1"} 0
http_outgoing_tls_duration_histogram_seconds_bucket{event="tls_handshake_done",recipient="domain",le="0.25"} 0
http_outgoing_tls_duration_histogram_seconds_bucket{event="tls_handshake_done",recipient="domain",le="0.5"} 0
http_outgoing_tls_duration_histogram_seconds_bucket{event="tls_handshake_done",recipient="domain",le="+Inf"} 0
http_outgoing_tls_duration_histogram_seconds_sum{event="tls_handshake_done",recipient="domain"} 0
http_outgoing_tls_duration_histogram_seconds_count{event="tls_handshake_done",recipient="domain"} 0
http_outgoing_tls_duration_histogram_seconds_bucket{event="tls_handshake_start",recipient="domain",le="0.05"} 0
http_outgoing_tls_duration_histogram_seconds_bucket{event="tls_handshake_start",recipient="domain",le="0.1"} 0
http_outgoing_tls_duration_histogram_seconds_bucket{event="tls_handshake_start",recipient="domain",le="0.25"} 0
http_outgoing_tls_duration_histogram_seconds_bucket{event="tls_handshake_start",recipient="domain",le="0.5"} 0
http_outgoing_tls_duration_histogram_seconds_bucket{event="tls_handshake_start",recipient="domain",le="+Inf"} 0
http_outgoing_tls_duration_histogram_seconds_sum{event="tls_handshake_start",recipient="domain"} 0
http_outgoing_tls_duration_histogram_seconds_count{event="tls_handshake_start",recipient="domain"} 0
```

<!--  Thanks for sending a pull request!  Here are some tips for you:
If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**If applicable**:
- [x] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
